### PR TITLE
Add support for Colombia.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Openpay dart package.
 
-Only token creation have been implemented here for now.
+Only token creation have been implemented here for now. Supported countries are Mexico and Colombia.
 
 ## Usage
 
@@ -10,7 +10,7 @@ Only token creation have been implemented here for now.
 import 'package:openpay/openpay.dart';
 
 main(List<String> arguments) async {
-  final openpay = Openpay('MERCHANT_ID', 'API_KEY', isSandboxMode: true);
+  final openpay = Openpay('MERCHANT_ID', 'API_KEY', country: Country.Mexico, isSandboxMode: true);
   final token = await openpay.createToken(
                       CardInfo(
                         '4111111111111111', // card number
@@ -24,7 +24,7 @@ main(List<String> arguments) async {
 }
 ``` 
 
-## Getting Started with flutter
+## Getting Started with Flutter
 
 This project is a starting point for a Dart
 [package](https://flutter.dev/developing-packages/),

--- a/lib/src/openpay.dart
+++ b/lib/src/openpay.dart
@@ -2,8 +2,15 @@ import 'dart:convert';
 
 import 'package:http/http.dart';
 
-const _sandboxUrl = 'https://sandbox-api.openpay.mx';
-const _prodUrl = 'https://api.openpay.mx';
+const Map<Country, String> _sandboxUrls = {
+   Country.Mexico: 'https://sandbox-api.openpay.mx',
+   Country.Colombia: 'https://sandbox-api.openpay.co',
+};
+
+const Map<Country, String> _productionUrls = {
+   Country.Mexico: 'https://api.openpay.mx',
+   Country.Colombia: 'https://api.openpay.co',
+};
 
 /// Openpay instance
 class Openpay {
@@ -17,11 +24,14 @@ class Openpay {
   /// Your public API Key
   final String apiKey;
 
-  Openpay(this.merchantId, this.apiKey, {this.isSandboxMode = false});
+  /// Which API endpoint to use.
+  final Country country;
+
+  Openpay(this.merchantId, this.apiKey, {this.isSandboxMode = false, this.country = Country.Mexico });
 
   String get _merchantBaseUrl => '$baseUrl/v1/$merchantId';
 
-  String get baseUrl => isSandboxMode ? _sandboxUrl : _prodUrl;
+  String get baseUrl => isSandboxMode ? _sandboxUrls[this.country]! : _productionUrls[this.country]!;
 
   /// Create a token from card data
   Future<TokenInfo> createToken(CardInfo card) async {
@@ -44,7 +54,10 @@ class Openpay {
       throw Exception('Error ${response.statusCode}, ${response.body}');
     }
   }
+}
 
+enum Country {
+  Mexico, Colombia
 }
 
 /// Card data representation class


### PR DESCRIPTION
This PR adds a parameter to the constructor that indicates with end point to use. Since the API is otherwise identical, that's the only thing to update. 

In order to keep backwards-compatibility, the parameter is optional and defaults to Mexico.